### PR TITLE
Fix for issue "Any wallet address can purchase ETHLend token for some…

### DIFF
--- a/contracts/EthLendICO.sol
+++ b/contracts/EthLendICO.sol
@@ -200,18 +200,18 @@ contract EthLendToken is StdToken
         assert(TOTAL_SOLD_TOKEN_SUPPLY_LIMIT==1000000000 * (1 ether / 1 wei));
     }
 
-    function buyTokens(address _buyer) public payable
+    function buyTokens() public payable
     {
         require(currentState==State.PresaleRunning || currentState==State.ICORunning);
 
         if(currentState==State.PresaleRunning){
-            return buyTokensPresale(_buyer);
+            return buyTokensPresale();
         }else{
-            return buyTokensICO(_buyer);
+            return buyTokensICO();
         }
     }
 
-    function buyTokensPresale(address _buyer) public payable onlyInState(State.PresaleRunning)
+    function buyTokensPresale() public payable onlyInState(State.PresaleRunning)
     {
         // min - 1 ETH
         require(msg.value >= (1 ether / 1 wei));
@@ -219,15 +219,15 @@ contract EthLendToken is StdToken
 
         require(presaleSoldTokens + newTokens <= PRESALE_TOKEN_SUPPLY_LIMIT);
 
-        balances[_buyer] += newTokens;
+        balances[msg.sender] += newTokens;
         supply+= newTokens;
         presaleSoldTokens+= newTokens;
         totalSoldTokens+= newTokens;
 
-        LogBuy(_buyer, newTokens);
+        LogBuy(msg.sender, newTokens);
     }
 
-    function buyTokensICO(address _buyer) public payable onlyInState(State.ICORunning)
+    function buyTokensICO() public payable onlyInState(State.ICORunning)
     {
         // min - 0.01 ETH
         require(msg.value >= ((1 ether / 1 wei) / 100));
@@ -235,12 +235,12 @@ contract EthLendToken is StdToken
 
         require(totalSoldTokens + newTokens <= TOTAL_SOLD_TOKEN_SUPPLY_LIMIT);
 
-        balances[_buyer] += newTokens;
+        balances[msg.sender] += newTokens;
         supply+= newTokens;
         icoSoldTokens+= newTokens;
         totalSoldTokens+= newTokens;
 
-        LogBuy(_buyer, newTokens);
+        LogBuy(msg.sender, newTokens);
     }
 
     function getPrice()constant returns(uint)
@@ -300,6 +300,6 @@ contract EthLendToken is StdToken
     // Default fallback function
     function() payable 
     {
-        buyTokens(msg.sender);
+        buyTokens();
     }
 }

--- a/contracts/EthLendICO.sol
+++ b/contracts/EthLendICO.sol
@@ -267,7 +267,8 @@ contract EthLendToken is StdToken
         
         currentState = _nextState;
         // enable/disable transfers
-        enableTransfers = (currentState==State.PresaleFinished) || (currentState==State.ICOFinished);
+        //enable transfers only after ICOFinished, disable otherwise
+        enableTransfers = (currentState==State.ICOFinished);
     }
 
     function withdrawEther() public onlyTokenManager

--- a/contracts/EthLendICO.sol
+++ b/contracts/EthLendICO.sol
@@ -262,6 +262,9 @@ contract EthLendToken is StdToken
 
     function setState(State _nextState) public onlyTokenManager
     {
+        //setState() method call shouldn't be entertained after ICOFinished
+        require(currentState != State.ICOFinished);
+        
         currentState = _nextState;
         // enable/disable transfers
         enableTransfers = (currentState==State.PresaleFinished) || (currentState==State.ICOFinished);


### PR DESCRIPTION
Fixes for following issues
Issue-1: Any wallet address can purchase ETHLend token for some other wallet address
Issue-2: After ICOFinished state, manager is still allowed to disable the fund transfer.
Issue-3: Enable token transfer only after ICOFinished, disable otherwise